### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
 
+    permissions:
+      contents: read
+      pages: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/transilvlad/robin/security/code-scanning/1](https://github.com/transilvlad/robin/security/code-scanning/1)

To fix this problem, add a `permissions` block to the workflow—either at the top level or at the job level. Set minimal permissions globally (e.g., `contents: read`). Then, for the specific job step that needs to deploy with write access to pages or contents (`Deploy to GitHub Pages`), you can override permissions at the job level if necessary (though with this workflow structure, job-level permissions suffice, since there is only one job). The best fix here is to add the following to the `build` job:

```yaml
permissions:
  contents: read
  pages: write
```

Alternatively, if only `contents: write` is required for `peaceiris/actions-gh-pages`, specify that. However, `pages: write` is newer and more secure for GitHub Pages deployments. Check the action documentation to confirm what permission is necessary. If unsure, both can be specified. Add this block above `runs-on` in the `build` job.

No new imports or definitions are needed; just add/edit lines in `.github/workflows/maven.yml` as described.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
